### PR TITLE
[WIP] Attach lxc containers to lxcbr0 by configuring a new network_mode parameter

### DIFF
--- a/lxc/driver.go
+++ b/lxc/driver.go
@@ -140,7 +140,7 @@ type TaskConfig struct {
 	LogLevel             string   `codec:"log_level"`
 	Verbosity            string   `codec:"verbosity"`
 	Volumes              []string `codec:"volumes"`
-	Network_mode         string   `codec:"network_mode"`
+	NetworkMode          string   `codec:"network_mode"`
 }
 
 // TaskState is the state which is encoded in the handle returned in
@@ -454,7 +454,7 @@ func (d *Driver) DestroyTask(taskID string, force bool) error {
 			handle.logger.Error("failed to destroy executor", "err", err)
 		}
 	}
-	
+
 	d.tasks.Delete(taskID)
 	return nil
 }

--- a/lxc/driver_test.go
+++ b/lxc/driver_test.go
@@ -91,6 +91,7 @@ func TestLXCDriver_Start_Wait(t *testing.T) {
 	d := NewLXCDriver(testlog.HCLogger(t)).(*Driver)
 	d.config.Enabled = true
 	d.config.AllowVolumes = true
+	d.config.NetworkMode = "host"
 
 	harness := dtestutil.NewDriverHarness(t, d)
 	task := &drivers.TaskConfig{
@@ -190,6 +191,7 @@ func TestLXCDriver_Start_Stop(t *testing.T) {
 	d := NewLXCDriver(testlog.HCLogger(t)).(*Driver)
 	d.config.Enabled = true
 	d.config.AllowVolumes = true
+	d.config.NetworkMode = "host"
 
 	harness := dtestutil.NewDriverHarness(t, d)
 	task := &drivers.TaskConfig{

--- a/lxc/lxc.go
+++ b/lxc/lxc.go
@@ -82,19 +82,19 @@ func (d *Driver) configureContainerNetwork(c *lxc.Container, taskConfig TaskConf
 	}
 
 	// switch lxc < 2.1
-	lxc_key_prefix := networkTypeConfigPrefix()
+	lxcKeyPrefix := networkTypeConfigPrefix()
 
 	if mode == "host" {
 		// Set the network type to none for shared "host" networking
-		if err := c.SetConfigItem(lxc_key_prefix+"type", "none"); err != nil {
+		if err := c.SetConfigItem(lxcKeyPrefix+"type", "none"); err != nil {
 			return fmt.Errorf("error setting network type configuration 'none': %v", err)
 		}
 	} else if mode == "bridge" {
 		// Set the network type to veth for attaching to lxc bridge
-		if err := c.SetConfigItem(lxc_key_prefix+"type", "veth"); err != nil {
+		if err := c.SetConfigItem(lxcKeyPrefix+"type", "veth"); err != nil {
 			return fmt.Errorf("error setting network type configuration 'veth': %v", err)
 		}
-		if err := c.SetConfigItem(lxc_key_prefix+"link", "lxcbr0"); err != nil {
+		if err := c.SetConfigItem(lxcKeyPrefix+"link", "lxcbr0"); err != nil {
 			return fmt.Errorf("error setting network link configuration: %v", err)
 		}
 	} else {

--- a/lxc/lxc.go
+++ b/lxc/lxc.go
@@ -72,21 +72,44 @@ func (d *Driver) initializeContainer(cfg *drivers.TaskConfig, taskConfig TaskCon
 	return c, nil
 }
 
-func (d *Driver) configureContainerNetwork(c *lxc.Container) error {
-	// Set the network type to none
-	if err := c.SetConfigItem(networkTypeConfigKey(), "none"); err != nil {
-		return fmt.Errorf("error setting network type configuration: %v", err)
+func (d *Driver) configureContainerNetwork(c *lxc.Container, taskConfig TaskConfig) error {
+
+	// use task specific network mode
+	mode := taskConfig.Network_mode
+	if mode == "" {
+		// but fallback to global driver config
+		mode = d.config.NetworkMode
+	}
+
+	// switch lxc < 2.1
+	lxc_key_prefix := networkTypeConfigPrefix()
+
+	if mode == "host" {
+		// Set the network type to none for shared "host" networking
+		if err := c.SetConfigItem(lxc_key_prefix+"type", "none"); err != nil {
+			return fmt.Errorf("error setting network type configuration 'none': %v", err)
+		}
+	} else if mode == "bridge" {
+		// Set the network type to veth for attaching to lxc bridge
+		if err := c.SetConfigItem(lxc_key_prefix+"type", "veth"); err != nil {
+			return fmt.Errorf("error setting network type configuration 'veth': %v", err)
+		}
+		if err := c.SetConfigItem(lxc_key_prefix+"link", "lxcbr0"); err != nil {
+			return fmt.Errorf("error setting network link configuration: %v", err)
+		}
+	} else {
+		return fmt.Errorf("Network mode is undefined")
 	}
 	return nil
 }
 
-func networkTypeConfigKey() string {
+func networkTypeConfigPrefix() string {
 	if lxc.VersionAtLeast(2, 1, 0) {
-		return "lxc.net.0.type"
+		return "lxc.net.0."
 	}
 
 	// prior to 2.1, network used
-	return "lxc.network.type"
+	return "lxc.network."
 }
 
 func (d *Driver) mountVolumes(c *lxc.Container, cfg *drivers.TaskConfig, taskConfig TaskConfig) error {

--- a/lxc/lxc.go
+++ b/lxc/lxc.go
@@ -75,7 +75,7 @@ func (d *Driver) initializeContainer(cfg *drivers.TaskConfig, taskConfig TaskCon
 func (d *Driver) configureContainerNetwork(c *lxc.Container, taskConfig TaskConfig) error {
 
 	// use task specific network mode
-	mode := taskConfig.Network_mode
+	mode := taskConfig.NetworkMode
 	if mode == "" {
 		// but fallback to global driver config
 		mode = d.config.NetworkMode


### PR DESCRIPTION
A new driver parameter "network_mode" switches the behavior of the containers network interface.
The default value "bridge",  will attach the container to the standard "lxcbr0" bridge. A value of "host" will instead share the network with the host, like it was in previous versions.

It's also possible to set the "network_mode" parameter within the task driver config. It simply overrides the global driver parameter and thus allows a different mode for specific containers.