### PR TITLE
cleanup lxc config loading

### DIFF
--- a/lxc/driver.go
+++ b/lxc/driver.go
@@ -47,10 +47,6 @@ var (
 			hclspec.NewAttr("volumes_enabled", "bool", false),
 			hclspec.NewLiteral("true"),
 		),
-		"default_config": hclspec.NewDefault(
-			hclspec.NewAttr("default_config", "string", false),
-			hclspec.NewLiteral("\""+lxc.GlobalConfigItem("lxc.default_config")+"\""),
-		),
 		"lxc_path": hclspec.NewAttr("lxc_path", "string", false),
 		"network_mode": hclspec.NewDefault(
 			hclspec.NewAttr("network_mode", "string", false),
@@ -88,6 +84,7 @@ var (
 		"verbosity":      hclspec.NewAttr("verbosity", "string", false),
 		"volumes":        hclspec.NewAttr("volumes", "list(string)", false),
 		"network_mode":   hclspec.NewAttr("network_mode", "string", false),
+		"config_file":    hclspec.NewAttr("config_file", "string", false),
 	})
 
 	// capabilities is returned by the Capabilities RPC and indicates what
@@ -138,8 +135,6 @@ type Config struct {
 
 	AllowVolumes bool `codec:"volumes_enabled"`
 
-	DefaultConfig string `codec:"default_config"`
-
 	LXCPath string `codec:"lxc_path"`
 
 	// default networking mode if not specified in task config
@@ -166,7 +161,7 @@ type TaskConfig struct {
 	Verbosity            string   `codec:"verbosity"`
 	Volumes              []string `codec:"volumes"`
 	NetworkMode          string   `codec:"network_mode"`
-	DefaultConfig        string   `codec:"default_config"`
+	ConfigFile           string   `codec:"config_file"`
 }
 
 // TaskState is the state which is encoded in the handle returned in

--- a/lxc/handle.go
+++ b/lxc/handle.go
@@ -36,7 +36,7 @@ type taskHandle struct {
 var (
 	LXCMeasuredCpuStats = []string{"System Mode", "User Mode", "Percent"}
 
-	LXCMeasuredMemStats = []string{"RSS", "Cache", "Swap", "Max Usage", "Kernel Usage", "Kernel Max Usage"}
+	LXCMeasuredMemStats = []string{"RSS", "Cache", "Swap"}
 )
 
 func (h *taskHandle) TaskStatus() *drivers.TaskStatus {
@@ -149,35 +149,6 @@ func (h *taskHandle) handleStats(ctx context.Context, ch chan *drivers.TaskResou
 			Cache:    memData["cache"],
 			Swap:     memData["swap"],
 			Measured: LXCMeasuredMemStats,
-		}
-
-		mu := h.container.CgroupItem("memory.max_usage_in_bytes")
-		for _, rawMemMaxUsage := range mu {
-			val, err := strconv.ParseUint(rawMemMaxUsage, 10, 64)
-			if err != nil {
-				h.logger.Error("failed to get max memory usage", "error", err)
-				continue
-			}
-			ms.MaxUsage = val
-		}
-		ku := h.container.CgroupItem("memory.kmem.usage_in_bytes")
-		for _, rawKernelUsage := range ku {
-			val, err := strconv.ParseUint(rawKernelUsage, 10, 64)
-			if err != nil {
-				h.logger.Error("failed to get kernel memory usage", "error", err)
-				continue
-			}
-			ms.KernelUsage = val
-		}
-
-		mku := h.container.CgroupItem("memory.kmem.max_usage_in_bytes")
-		for _, rawMaxKernelUsage := range mku {
-			val, err := strconv.ParseUint(rawMaxKernelUsage, 10, 64)
-			if err != nil {
-				h.logger.Error("failed tog get max kernel memory usage", "error", err)
-				continue
-			}
-			ms.KernelMaxUsage = val
 		}
 
 		taskResUsage := drivers.TaskResourceUsage{

--- a/lxc/lxc.go
+++ b/lxc/lxc.go
@@ -76,14 +76,14 @@ func (d *Driver) initializeContainer(cfg *drivers.TaskConfig, taskConfig TaskCon
 	}
 
 	// use task specific config
-	defaultConfig := taskConfig.DefaultConfig
-	if defaultConfig == "" {
-		// but fallback to global config
-		defaultConfig = d.config.DefaultConfig
+	lxcConfigFile := taskConfig.ConfigFile
+	if taskConfig.ConfigFile == "" {
+		// fallback to global config
+		lxcConfigFile = lxc.GlobalConfigItem("lxc.default_config")
 	}
-	err = c.LoadConfigFile(defaultConfig)
+	err = c.LoadConfigFile(lxcConfigFile)
 	if err != nil {
-		d.logger.Warn("failed to load default config", "path", defaultConfig, "error", err)
+		d.logger.Warn("failed to load lxc config file", "path", lxcConfigFile, "error", err)
 	}
 
 	return c, nil


### PR DESCRIPTION
replace default_config task option with config_file

Only support config_file on the task to behave exactly as the lxc command line tools. The default_config file location is provided automatically by the lxc library and can already by overridden per-system (see man lxc.system.conf).

Also removed various stats no longer supported with cgroups v2 and some were removed in kernel 5.4+.